### PR TITLE
Add Github Actions for deployments

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,8 +29,6 @@ jobs:
           node-version: 12.x
 
       - name: Install and Build
-        env:
-          CI: true
         run: yarn --cwd=website/docs install && yarn --cwd=website/docs build
 
       - name: Deploy


### PR DESCRIPTION
This PR implements a Github Action workflow:

- Automatically build and deploy website whenever there are changes to `website/docs`, which can also be manually triggered.

I'm still thinking if we need a separate one that can take a version as input and cuts-off a new release and build and deploy, which requires the Action to commit and push to the repo. It can help further automate the release process, but a bit tricky to steamline with the main repo.
