### PR TITLE
Add legacy links

### DIFF
--- a/website/docs/src/me/README.md
+++ b/website/docs/src/me/README.md
@@ -1,7 +1,3 @@
----
-sidebar: auto
----
-
 # Me
 
 Redirecting you to https://yuanming.taichi.graphics/ ...

--- a/website/docs/src/mpm_course2019/README.md
+++ b/website/docs/src/mpm_course2019/README.md
@@ -1,7 +1,3 @@
----
-sidebar: auto
----
-
 # On hybrid lagrangian-eulerian simulation methods: practical notes and high-performance aspects
 
 Redirecting to https://yuanming.taichi.graphics/publication/2019-mpm-tutorial/ ...


### PR DESCRIPTION
<!-- Welcome to Taichi's documentation site and thank you for your contribution! -->

### Changes

Added redirecting pages for `taichi.graphics/me` and `taichi.graphics/mpm_course2019` (otherwise my collaborators will kill me...)

### Review Instructions

The implementation is hacky but it works well. If you know a more systematic solution, please let me know :-)

I have moved http://taichi.graphics to http://legacy.taichi.graphics - Ready to link http://taichi.graphics/ to this site anytime!