### PR TITLE
Fix the background color of code highlight in admonitions.

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -138,13 +138,6 @@ html[data-theme='dark'] .header-github-link:before {
   background: transparent;
 }
 
-/* Revert the code background and text in admonitions
-   to make them more clear */
-.admonition .admonition-content code {
-  background-color: var(--ifm-code-color);
-  color: var(--ifm-code-background)
-}
-
 /* Highlight text */
 #inline-blue {
   background-color: #2780e3;


### PR DESCRIPTION
<!-- Welcome to Taichi's documentation site and thank you for your contribution! -->

### Purpose
<!-- Please explain the purpose of this PR OR include links to any ticket that it fixes: -->

- The lateset version of Docusaurus improved how inline code looks like in admonitions, which makes our own fix like a bug. This PR fixes it.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

<!-- TO DOCUMENTATION WRITERS: Please always work on `website/docs/develop` only, which is the latest "develop" directory of the documentation. Think twice if you really need to update other older versions of the docs! -->

- Remove the CSS for admonition.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
