### PR TITLE
[ci] Add doc sync action

### DIFF
--- a/.github/workflows/doc-sync.yml
+++ b/.github/workflows/doc-sync.yml
@@ -33,7 +33,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@v3
         with:
-          token: ${{ secrets.GardenerPAT }}
+          token: ${{ secrets.GARDENER_PAT }}
           path: target
           commit-message: Sync and update documentation content.
           committer: Taichi Gardener <taichigardener@gmail.com>
@@ -55,7 +55,7 @@ jobs:
         if: steps.create-pr.outputs.pull-request-operation == 'created'
         uses: peter-evans/enable-pull-request-automerge@v1
         with:
-          token: ${{ secrets.GardenerPAT }}
+          token: ${{ secrets.GARDENER_PAT }}
           pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
           merge-method: squash
 

--- a/.github/workflows/doc-sync.yml
+++ b/.github/workflows/doc-sync.yml
@@ -1,0 +1,68 @@
+name: Sync and update docs from the main repo
+
+on:
+  schedule:
+    # update it every day at 00:00
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  sync-docs:
+    runs-on: "ubuntu-20.04"
+    steps:
+      - name: Checkout Taichi main repo
+        uses: actions/checkout@v2
+        with:
+          repository: taichi-dev/taichi
+          path: source
+
+      - name: Checkout Taichi docs repo
+        uses: actions/checkout@v2
+        with:
+          repository: taichi-dev/docs.taichi.graphics
+          path: target
+
+      - name: Sync and stage changes
+        run: |
+          # faithfully copy source docs to target
+          # remove extra files to make them identical
+          # also print the logs in human readable format
+          rsync -avh --delete source/docs/lang/ target/website/docs/lang
+
+      - name: Create a Pull Request
+        id: create-pr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GardenerPAT }}
+          path: target
+          commit-message: Sync and update documentation content.
+          committer: Taichi Gardener <taichigardener@gmail.com>
+          author: Taichi Gardener <taichi-gardener@users.noreply.github.com>
+          signoff: false
+          base: master
+          branch: sync-documentation
+          delete-branch: true
+          draft: false
+          title: '[Cron] Sync and update documentation content'
+          body: |
+            - Synced with *today's* date.
+            - Auto-generated.
+            - Will be auto-merged.
+          labels: |
+            automation
+
+      - name: Enable auto-merge on the Pull Request
+        if: steps.create-pr.outputs.pull-request-operation == 'created'
+        uses: peter-evans/enable-pull-request-automerge@v1
+        with:
+          token: ${{ secrets.GardenerPAT }}
+          pull-request-number: ${{ steps.create-pr.outputs.pull-request-number }}
+          merge-method: squash
+
+      - name: Auto approve the Pull Request
+        if: steps.create-pr.outputs.pull-request-operation == 'created'
+        uses: juliangruber/approve-pull-request-action@v1
+        with:
+          # we use Action Bot to approve since you can't approve your own PR
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ steps.create-pr.outputs.pull-request-number }}


### PR DESCRIPTION
# The goal

A Cron that can be triggered on demand OR periodically pulls the latest content of the `docs` subdirectory of `taichi-dev/taichi` and overwrites the content of `website/docs/lang` subdirectory of  `taichi-dev/docs.taichi.graphics`. 

- It is preferred to perform the overwrite through a Pull Request, to let all doc changes come through the PR tests, also in case we want to revert it at anytime.
- The overwrite will be performed by @taichi-gardener.

## Why not git submodules?

- `submodules` does not support pointing at a subdirectory, just like `git` doesn't support narrow clones. The main repository has `docs` as a subdirectory. Existing solutions such as `filter-branch` have their own pitfalls and don't really make our life easier than a Cron job.
- `submodules` creates more VCS features than we need and may confuse developers and contributors.

## Behavior

- If there are changes to the source docs in the main repo, the changes will be pushed to a new `sync-documentation` , a pull request will be created, approved and merged.
- If there are no changes to the source docs in the main repo, nothing happens and the action exits silently.
- If a pull request from `sync-documentation` already exists and there are no further changes then the action exits silently.
- If a pull request from `sync-documentation` exists and new doc changes on the base branch make the pull request unnecessary (i.e. there is no longer a diff between the `sync-documentation` branch and the `master` branch of this repo), the pull request is automatically closed, and `sync-documentation` will be deleted.
- Any structural changes to the `docs` directory will be forcefully merged into this repo, redundant files will be removed. This won't affect the `en` , i.e. the default locale, but will affect how other locales behave. It requires i18n/translation groups to update the structure accordingly on https://translate.taichi.graphics.

## Notes

- This workflow heavily relies on the [Create Pull Request Action]([https://github.com/peter-evans/create-pull-request](https://github.com/peter-evans/create-pull-request)).
- Changes to the repo settings to make this work properly
    - `master` branch now has `Require pull request reviews before merging` protection.
    - `GARDENER_PAT` has been added to the `Repository secrets`, which is a Taichi-Gardener PAT with the `repo` scope.
    - `Allow auto-merge` is enabled now.