### PR TITLE
Fix ahead the sidebar path.

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -76,7 +76,7 @@ module.exports = {
       items: [
         {
           type: 'doc',
-          docId: 'lang/articles/get-started',
+          docId: 'lang/articles/get-started/index',
           position: 'right',
           label: 'Docs',
           className: 'animated-anchor-link',


### PR DESCRIPTION
<!-- Welcome to Taichi's documentation site and thank you for your contribution! -->

### Purpose
<!-- Please explain the purpose of this PR OR include links to any ticket that it fixes: -->

- This PR should be merged ahead of https://github.com/taichi-dev/taichi/pull/4360 in order for the preview to work properly.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

<!-- TO DOCUMENTATION WRITERS: Please always work on `website/docs/develop` only, which is the latest "develop" directory of the documentation. Think twice if you really need to update other older versions of the docs! -->

- No changes.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- We should add unique `slugId`s for all documents ASAP to prevent this from happening in the future. (e.g. `get-started` will be referenced as `get-started` instead of `lang/articles/get-started/index` across the docsite... thus moving around docs won't be such an issue.)
- There won't be a "downtime window" between this PR's merge and the other PR's merge, when users try to click the `Dcos` button on the NavBar, since this PR will fail the deployment, FTR. (otherwise we cannot get rid of the deadlock...)