### PR TITLE
add flaturl and tab support

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -226,6 +226,7 @@ module.exports = {
       }
     },
   },
+  themes: [path.join(__dirname, './plugins/docusaurus-theme-extends/src')],
   presets: [
     [
       '@docusaurus/preset-classic',
@@ -252,8 +253,8 @@ module.exports = {
             },
           },
           remarkPlugins: [
-            [variablePlugin, { data: variables }],
-            [fragmentPlugin, { prefix: 'fragments', baseUrl: __dirname + '/fragments' }]
+            [variablePlugin, { data: variables, fail: false }],
+            [fragmentPlugin, { prefix: 'fragments', fail: false, baseUrl: __dirname + '/fragments' }]
           ],
         },
         blog: {

--- a/website/package.json
+++ b/website/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "docusaurus build",
+    "build": "yarn run validateplugin && docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
@@ -15,7 +15,8 @@
     "crowdin": "crowdin",
     "crowdin:sync": "docusaurus write-translations && crowdin upload && crowdin download",
     "crowdin:upload": "docusaurus write-translations && crowdin upload",
-    "apiversion": "node ./apiversion.js"
+    "apiversion": "node ./apiversion.js",
+    "validateplugin": "node ./scripts/validation/index.js"
   },
   "dependencies": {
     "@crowdin/cli": "^3.6.4",

--- a/website/plugins/docusaurus-theme-extends/src/index.js
+++ b/website/plugins/docusaurus-theme-extends/src/index.js
@@ -1,0 +1,10 @@
+const path = require('path')
+
+module.exports = function(context) {
+  return {
+    name: 'docusaurus-sidebarItems',
+    getThemePath() {
+      return path.resolve(__dirname, '../src/theme');
+    },
+  }
+}

--- a/website/plugins/docusaurus-theme-extends/src/theme/DocSidebarItem/index.js
+++ b/website/plugins/docusaurus-theme-extends/src/theme/DocSidebarItem/index.js
@@ -1,0 +1,267 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React, {useEffect, useMemo} from 'react';
+import clsx from 'clsx';
+import {
+  isActiveSidebarItem,
+  usePrevious,
+  Collapsible,
+  useCollapsible,
+  findFirstCategoryLink,
+  ThemeClassNames,
+  useThemeConfig,
+  useDocSidebarItemsExpandedState,
+  isSamePath,
+} from '@docusaurus/theme-common';
+import Link from '@docusaurus/Link';
+import isInternalUrl from '@docusaurus/isInternalUrl';
+import {translate} from '@docusaurus/Translate';
+import IconExternalLink from '@theme/IconExternalLink';
+import DocSidebarItems from '@theme/DocSidebarItems';
+import styles from './styles.module.css';
+import useIsBrowser from '@docusaurus/useIsBrowser';
+export default function DocSidebarItem({item, ...props}) {
+  switch (item.type) {
+    case 'category':
+      return <DocSidebarItemCategory item={item} {...props} />;
+
+    case 'html':
+      return <DocSidebarItemHtml item={item} {...props} />;
+
+    case 'link':
+    default:
+      return <DocSidebarItemLink item={item} {...props} />;
+  }
+} // If we navigate to a category and it becomes active, it should automatically
+// expand itself
+
+function useAutoExpandActiveCategory({isActive, collapsed, setCollapsed}) {
+  const wasActive = usePrevious(isActive);
+  useEffect(() => {
+    const justBecameActive = isActive && !wasActive;
+
+    if (justBecameActive && collapsed) {
+      setCollapsed(false);
+    }
+  }, [isActive, wasActive, collapsed, setCollapsed]);
+}
+/**
+ * When a collapsible category has no link, we still link it to its first child
+ * during SSR as a temporary fallback. This allows to be able to navigate inside
+ * the category even when JS fails to load, is delayed or simply disabled
+ * React hydration becomes an optional progressive enhancement
+ * see https://github.com/facebookincubator/infima/issues/36#issuecomment-772543188
+ * see https://github.com/facebook/docusaurus/issues/3030
+ */
+
+function useCategoryHrefWithSSRFallback(item) {
+  const isBrowser = useIsBrowser();
+  return useMemo(() => {
+    if (item.href) {
+      return item.href;
+    } // In these cases, it's not necessary to render a fallback
+    // We skip the "findFirstCategoryLink" computation
+
+    if (isBrowser || !item.collapsible) {
+      return undefined;
+    }
+
+    return findFirstCategoryLink(item);
+  }, [item, isBrowser]);
+}
+
+function DocSidebarItemCategory({
+  item,
+  onItemClick,
+  activePath,
+  level,
+  index,
+  ...props
+}) {
+  const {items, label, collapsible, className, href} = item;
+  let hrefWithSSRFallback = useCategoryHrefWithSSRFallback(item);
+  const isActive = isActiveSidebarItem(item, activePath);
+  const isCurrentPage = isSamePath(href, activePath);
+  const {collapsed, setCollapsed} = useCollapsible({
+    // active categories are always initialized as expanded
+    // the default (item.collapsed) is only used for non-active categories
+    initialState: () => {
+      if (!collapsible) {
+        return false;
+      }
+
+      return isActive ? false : item.collapsed;
+    },
+  });
+
+  if (!collapsible && !hrefWithSSRFallback && item.items && item.items.length > 0) {
+    hrefWithSSRFallback = item.items[0].href
+  }
+  useAutoExpandActiveCategory({
+    isActive,
+    collapsed,
+    setCollapsed,
+  });
+  const {expandedItem, setExpandedItem} = useDocSidebarItemsExpandedState();
+
+  function updateCollapsed(toCollapsed = !collapsed) {
+    setExpandedItem(toCollapsed ? null : index);
+    setCollapsed(toCollapsed);
+  }
+
+  const {autoCollapseSidebarCategories} = useThemeConfig();
+  useEffect(() => {
+    if (
+      collapsible &&
+      expandedItem &&
+      expandedItem !== index &&
+      autoCollapseSidebarCategories
+    ) {
+      setCollapsed(true);
+    }
+  }, [
+    collapsible,
+    expandedItem,
+    index,
+    setCollapsed,
+    autoCollapseSidebarCategories,
+  ]);
+  return (
+    <li
+      className={clsx(
+        ThemeClassNames.docs.docSidebarItemCategory,
+        ThemeClassNames.docs.docSidebarItemCategoryLevel(level),
+        'menu__list-item',
+        {
+          'menu__list-item--collapsed': collapsed,
+        },
+        className,
+      )}>
+      <div
+        className={clsx('menu__list-item-collapsible', {
+          'menu__list-item-collapsible--active': isCurrentPage,
+        })}>
+        <Link
+          className={clsx('menu__link', {
+            'menu__link--sublist': collapsible && !href,
+            'menu__link--active': isActive,
+          })}
+          onClick={
+            collapsible
+              ? (e) => {
+                  onItemClick?.(item);
+
+                  if (href) {
+                    updateCollapsed(false);
+                  } else {
+                    e.preventDefault();
+                    updateCollapsed();
+                  }
+                }
+              : () => {
+                  onItemClick?.(item);
+                }
+          }
+          aria-current={isCurrentPage ? 'page' : undefined}
+          href={collapsible ? hrefWithSSRFallback ?? '#' : hrefWithSSRFallback}
+          {...props}>
+          {label}
+        </Link>
+        {href && collapsible && (
+          <button
+            aria-label={translate(
+              {
+                id: 'theme.DocSidebarItem.toggleCollapsedCategoryAriaLabel',
+                message: "Toggle the collapsible sidebar category '{label}'",
+                description:
+                  'The ARIA label to toggle the collapsible sidebar category',
+              },
+              {
+                label,
+              },
+            )}
+            type="button"
+            className="clean-btn menu__caret"
+            onClick={(e) => {
+              e.preventDefault();
+              updateCollapsed();
+            }}
+          />
+        )}
+      </div>
+      {collapsible && (<Collapsible lazy as="ul" className="menu__list" collapsed={collapsed}>
+        <DocSidebarItems
+          items={items}
+          tabIndex={collapsed ? -1 : 0}
+          onItemClick={onItemClick}
+          activePath={activePath}
+          level={level + 1}
+        />
+      </Collapsible>)}
+    </li>
+  );
+}
+
+function DocSidebarItemHtml({item, level, index}) {
+  const {value, defaultStyle, className} = item;
+  return (
+    <li
+      className={clsx(
+        ThemeClassNames.docs.docSidebarItemLink,
+        ThemeClassNames.docs.docSidebarItemLinkLevel(level),
+        defaultStyle && `${styles.menuHtmlItem} menu__list-item`,
+        className,
+      )}
+      key={index} // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{
+        __html: value,
+      }}
+    />
+  );
+}
+
+function DocSidebarItemLink({
+  item,
+  onItemClick,
+  activePath,
+  level,
+  index,
+  ...props
+}) {
+  const {href, label, className} = item;
+  const isActive = isActiveSidebarItem(item, activePath);
+  return (
+    <li
+      className={clsx(
+        ThemeClassNames.docs.docSidebarItemLink,
+        ThemeClassNames.docs.docSidebarItemLinkLevel(level),
+        'menu__list-item',
+        className,
+      )}
+      key={label}>
+      <Link
+        className={clsx('menu__link', {
+          'menu__link--active': isActive,
+        })}
+        aria-current={isActive ? 'page' : undefined}
+        to={href}
+        {...(isInternalUrl(href) && {
+          onClick: onItemClick ? () => onItemClick(item) : undefined,
+        })}
+        {...props}>
+        {isInternalUrl(href) ? (
+          label
+        ) : (
+          <span>
+            {label}
+            <IconExternalLink />
+          </span>
+        )}
+      </Link>
+    </li>
+  );
+}

--- a/website/plugins/docusaurus-theme-extends/src/theme/DocSidebarItem/styles.module.css
+++ b/website/plugins/docusaurus-theme-extends/src/theme/DocSidebarItem/styles.module.css
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@media (min-width: 997px) {
+  .menuHtmlItem {
+    padding: var(--ifm-menu-link-padding-vertical)
+      var(--ifm-menu-link-padding-horizontal);
+  }
+}

--- a/website/plugins/docusaurus-theme-extends/src/theme/LinkTabs/index.js
+++ b/website/plugins/docusaurus-theme-extends/src/theme/LinkTabs/index.js
@@ -1,0 +1,38 @@
+
+import React from 'react';
+import clsx from 'clsx';
+
+import Link from '@docusaurus/Link';
+
+export default function LinkTabs({selectedValue, values, className}) {
+  return (
+    <div className="tabs-container">
+      <ul
+        role="tablist"
+        aria-orientation="horizontal"
+        className={clsx(
+          'tabs', 'tabs--block',
+          className,
+        )}>
+        {values.map(({value, label, href, attributes}) => (
+          <Link to={href} key={value}>
+            <li
+              role="tab"
+              tabIndex={selectedValue === value ? 0 : -1}
+              aria-selected={selectedValue === value}
+              {...attributes}
+              className={clsx(
+                'tabs__item',
+                attributes?.className,
+                {
+                  'tabs__item--active': selectedValue === value,
+                },
+              )}>
+              {label ?? value}
+            </li>
+          </Link>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/website/plugins/remark-plugins/fragments/index.js
+++ b/website/plugins/remark-plugins/fragments/index.js
@@ -2,10 +2,10 @@ const tokenizer = require('./tokenizer')
 const utils = require('./utils')
 
 module.exports = function(options) {
-  const { prefix, baseUrl, name, quiet, fail } = utils.withDefaultOption(options)
+  const { prefix, baseUrl, name, quiet, fail, onError } = utils.withDefaultOption(options)
   const parser = this.Parser
   const { blockTokenizers, blockMethods, interruptParagraph } = parser.prototype
-  blockTokenizers[name] = tokenizer(prefix, baseUrl, quiet, fail)
+  blockTokenizers[name] = tokenizer(prefix, baseUrl, quiet, fail, onError)
   blockMethods.splice(blockMethods.indexOf('newline') + 1, 0, name)
   interruptParagraph.unshift([name])
   blockTokenizers[name].notInLink = true

--- a/website/plugins/remark-plugins/fragments/tokenizer.js
+++ b/website/plugins/remark-plugins/fragments/tokenizer.js
@@ -1,7 +1,7 @@
 const path = require('path')
 const fs = require('fs')
 
-function tokenizer (prefix, baseUrl, quiet, fail) {
+function tokenizer (prefix, baseUrl, quiet, fail, onError) {
   return function (eat, value, silent) {
 
     if (!value.startsWith('{{')) return
@@ -21,7 +21,6 @@ function tokenizer (prefix, baseUrl, quiet, fail) {
       if (silent) {
         return true
       }
-
       sub = sub.substring(prefix.length)
       const fileAbsPath = path.join(baseUrl, sub);
       let content
@@ -31,8 +30,9 @@ function tokenizer (prefix, baseUrl, quiet, fail) {
       try {
         content = fs.readFileSync(fileAbsPath, 'utf8');
       } catch (e) {
+        const message = 'Could not resolve fragment `' + fileAbsPath + '`'
+        onError?.(message, start)
         if (!quiet) {
-          const message = 'Could not resolve fragment `' + fileAbsPath + '`'
           if (fail) {
             return file.fail(message, start, 'fragment:undef-fragment')
           } else {

--- a/website/plugins/remark-plugins/variables/index.js
+++ b/website/plugins/remark-plugins/variables/index.js
@@ -10,9 +10,9 @@ function locator (opening) {
 }
 
 module.exports = function variable(options) {
-  const { data, name, fence, quiet, fail } = utils.withDefaultOption(options)
+  const { data, name, fence, quiet, fail, onError } = utils.withDefaultOption(options)
   const { inlineTokenizers, inlineMethods } = this.Parser.prototype
-  inlineTokenizers[name] = tokenizer(name, data, fence, quiet, fail)
+  inlineTokenizers[name] = tokenizer(name, data, fence, quiet, fail, onError)
   inlineMethods.splice(inlineMethods.indexOf('url'), 0, name)
   inlineTokenizers[name].locator = locator(fence[0])
   function visitor(node) {

--- a/website/plugins/remark-plugins/variables/tokenizer.js
+++ b/website/plugins/remark-plugins/variables/tokenizer.js
@@ -1,6 +1,6 @@
 module.exports = tokenizer
 
-function tokenizer (name, data, fence, quiet, fail) {
+function tokenizer (name, data, fence, quiet, fail, onError) {
   return function (eat, value, silent) {
 
     if (!value.startsWith(fence[0])) return
@@ -41,7 +41,7 @@ function tokenizer (name, data, fence, quiet, fail) {
       if (!found && !quiet) {
         sub = sub.indexOf('.') === 0 ? sub : '.' + sub
         const message = 'Could not resolve `var' + sub + '`'
-
+        onError?.(message, now)
         if (fail) {
           return file.fail(message, now, 'variables:undef-variable')
         } else {

--- a/website/scripts/flaturl/category.js
+++ b/website/scripts/flaturl/category.js
@@ -1,0 +1,50 @@
+const fs = require('fs-extra');
+const Yaml = require('js-yaml');
+const globby = require('globby');
+const path = require('path');
+
+const utils_validation = require('@docusaurus/utils-validation');
+
+const { Joi } = utils_validation;
+
+const categoryMetadataFileSchema = Joi.object({
+  label: Joi.string(),
+  position: Joi.number(),
+  collapsed: Joi.boolean(),
+  collapsible: Joi.boolean(),
+  className: Joi.string(),
+  isTab: Joi.boolean(),
+});
+
+async function readTabCategoryMetadata(contentPath) {
+  const categoryFiles = await globby('**/_category_.{json,yml,yaml}', {
+    cwd: contentPath,
+  });
+  const ret = [];
+  for (const item of categoryFiles) {
+    const source = path.join(contentPath, item);
+    const content = await fs.readFile(source, 'utf-8');
+    const metadata = utils_validation.Joi.attempt(
+      Yaml.load(content),
+      categoryMetadataFileSchema
+    );
+
+    if (metadata.isTab) {
+      ret.push({
+        source,
+        metadata,
+      });
+    }
+  }
+  return ret;
+}
+
+async function writeToFile(content, source) {
+  const str = JSON.stringify(content, null, 2)
+  await fs.writeFile(source, str)
+}
+
+module.exports = {
+  readTabCategoryMetadata,
+  writeToFile
+};

--- a/website/scripts/flaturl/doc.js
+++ b/website/scripts/flaturl/doc.js
@@ -1,0 +1,108 @@
+const matter = require('gray-matter');
+const fs = require('fs-extra');
+const globby = require('globby');
+const path = require('path');
+
+const utils_validation = require('@docusaurus/utils-validation');
+
+const {
+  parseMarkdownString,
+} = require('@docusaurus/utils');
+
+const {
+  DefaultNumberPrefixParser,
+} = require('../../node_modules/@docusaurus/plugin-content-docs/lib/numberPrefix');
+
+
+const DocFrontMatterSchema = utils_validation.JoiFrontMatter.object({
+  id: utils_validation.JoiFrontMatter.string(),
+  title: utils_validation.JoiFrontMatter.string().allow(''),
+  slug: utils_validation.JoiFrontMatter.string(),
+  sidebar_label: utils_validation.JoiFrontMatter.string(),
+  sidebar_position: utils_validation.JoiFrontMatter.number(),
+  parse_number_prefixes: utils_validation.JoiFrontMatter.boolean(),
+}).unknown();
+
+async function getDocMetadata(contentPath) {
+  const pagesFiles = await globby('**/*.{md,mdx}', {
+    cwd: contentPath,
+  });
+
+  async function toMetadata(relativeSource) {
+    const source = path.join(contentPath, relativeSource);
+
+    const content = await fs.readFile(source, 'utf-8');
+
+    const { frontMatter: unsafeFrontMatter, contentTitle, content: body } =
+      parseMarkdownString(content);
+
+    const frontMatter = utils_validation.validateFrontMatter(
+      unsafeFrontMatter,
+      DocFrontMatterSchema
+    );
+
+    let {
+      id,
+      parse_number_prefixes: parseNumberPrefixes = true,
+      sidebar_position: sidebarPos,
+      slug,
+    } = frontMatter;
+
+    const sourceFileNameWithoutExtension = path.basename(
+      source,
+      path.extname(relativeSource)
+    );
+
+    const { filename: unprefixedFileName } = parseNumberPrefixes
+      ? DefaultNumberPrefixParser(sourceFileNameWithoutExtension)
+      : { filename: sourceFileNameWithoutExtension, numberPrefix: undefined };
+
+    const baseID = id ?? unprefixedFileName;
+    const title = frontMatter.title ?? contentTitle ?? baseID;
+
+    return {
+      id: baseID,
+      title,
+      body,
+      slug,
+      sidebarPos,
+      source,
+      frontMatter: unsafeFrontMatter,
+    };
+  }
+
+  const docs = [];
+  for (const item of pagesFiles) {
+    const meta = await toMetadata(item);
+    docs.push(meta);
+  }
+
+  return docs
+}
+
+function flatUrl(metadata, baseurl) {
+  let slug = metadata.slug
+  if (!slug || slug.length === 0) {
+    slug = `${baseurl}/${metadata.id}`
+    metadata.slug = slug
+  }
+  return metadata
+}
+
+async function writeDoc(metadata, frombase, tobase) {
+  const frontMatter = metadata.frontMatter
+  frontMatter.slug = metadata.slug
+
+  const relative = path.relative(frombase, metadata.source)
+  const npath = path.resolve(tobase, relative)
+
+  const data = matter.stringify(metadata.body, frontMatter)
+
+  await fs.outputFile(npath, data)
+}
+
+module.exports = {
+  getDocMetadata,
+  flatUrl,
+  writeDoc
+}

--- a/website/scripts/flaturl/index.js
+++ b/website/scripts/flaturl/index.js
@@ -1,0 +1,14 @@
+const docutils = require('./doc')
+const tabutils = require('./tab')
+
+async function flatUrl(frombase, tobase, baseurl) {
+  const metadatas = await docutils.getDocMetadata(frombase)
+  for (const metadata of metadatas) {
+    const n = docutils.flatUrl(metadata, baseurl)
+    await docutils.writeDoc(n, frombase, tobase)
+  }
+}
+
+flatUrl('./docs', './docs', '/lang/articles').then(() => {
+  tabutils.findTabAndReplace('./docs')
+})

--- a/website/scripts/flaturl/tab.js
+++ b/website/scripts/flaturl/tab.js
@@ -1,0 +1,64 @@
+const path = require('path')
+const fs = require('fs-extra')
+const matter = require('gray-matter');
+
+const categoryUtils = require('./category')
+const docUtils = require('./doc')
+
+function generateTabContent(tabstr, activeKey, ignoreImport = false) {
+  return `${ignoreImport ? "" : "import LinkTabs from '@theme/LinkTabs';"}
+
+<LinkTabs values={${tabstr}} selectedValue='${activeKey}' />`
+}
+
+function replaceTabPlaceholder(id, content, tabstr) {
+  const arr = content.split('\n')
+  const reg = new RegExp(`^{{([\\s\\S]+?)}}$`, 'g')
+
+  let ignoreImport = false
+  let newcontent = ''
+  for (const item of arr) {
+    let normalized = item.trim()
+    if (normalized.startsWith('{{')) {
+      const match = reg.exec(normalized)
+      if (match) {
+        const t = match[1].trim()
+        if (t === 'tab') {
+          normalized = generateTabContent(tabstr, id, ignoreImport)
+          ignoreImport = true
+        }
+      }
+    }
+    newcontent += '\n' + normalized
+  }
+  return newcontent
+}
+
+async function findTabAndReplace(frombase) {
+  const tabCategories = await categoryUtils.readTabCategoryMetadata(frombase)
+  for (const category of tabCategories) {
+    let metadatas = await docUtils.getDocMetadata(path.dirname(category.source))
+    metadatas = metadatas.sort((a, b) => a.sidebarPos - b.sidebarPos)
+    const tabs = []
+    for (const metadata of metadatas) {
+      tabs.push({ value: metadata.id, label: metadata.title, href: metadata.slug })
+    }
+    const tabstr = JSON.stringify(tabs)
+    for (const item of metadatas) {
+      const body = replaceTabPlaceholder(item.id, item.body, tabstr)
+      const data = matter.stringify(body, item.frontMatter)
+      await fs.writeFile(item.source, data)
+    }
+    categoryUtils.writeToFile({
+      label: category.metadata.label,
+      position: category.metadata.position,
+      collapsed: true,
+      collapsible: false,
+      className: category.metadata.className,
+    }, category.source)
+  }
+}
+
+module.exports = {
+  findTabAndReplace
+}

--- a/website/scripts/validation/index.js
+++ b/website/scripts/validation/index.js
@@ -1,0 +1,46 @@
+const fragmentPlugin = require('../../plugins/remark-plugins/fragments');
+const variablePlugin = require('../../plugins/remark-plugins/variables');
+const variables = require('../..//variables');
+const docutils = require('../flaturl/doc');
+
+const mdxLoader = require('@docusaurus/mdx-loader').default;
+const {
+  reportMessage,
+} = require('@docusaurus/utils')
+
+const loadContext = (errors) => {
+  return {
+    async: () => {
+      return () => {}
+    },
+    getOptions: () => ({
+      remarkPlugins: [
+        [variablePlugin, { data: variables, fail: false, onError: (err, line) => {errors.push([err, line])} }],
+        [fragmentPlugin, { prefix: 'fragments', fail: false, baseUrl: process.cwd() + '/fragments', onError: (err, line) => {errors.push([err, line])} }]
+      ],
+    })
+  }
+}
+
+async function validateFragmentsAndVariables(contentPath) {
+  const docs = await docutils.getDocMetadata(contentPath);
+  let haserrors = false
+  for (const doc of docs) {
+    const errors = []
+    const context = loadContext(errors)
+    const mdxLoaderWithContext = mdxLoader.bind(context)
+    await mdxLoaderWithContext(doc.body)
+    if (errors.length > 0) {
+      haserrors = true
+      reportMessage(`- on source page path = ${doc.source}`, 'error')
+      for (const item of errors) {
+        reportMessage(`   line:${item[1].line} Column:${item[1].column} ${item[0]}`, 'error')
+      }
+    }
+  }
+  if (haserrors) {
+    process.exit(1)
+  }
+}
+
+validateFragmentsAndVariables('./docs')


### PR DESCRIPTION

### Purpose
- url only show last level
- support tab switch to different doc
- extends docusaurus(only have broken check) validation

### Changes
- add docusaurus theme extension plugin
- add script to flat url and support tab
- add validation to validate variable and fragment

### how to use
#### 1. how to add tab (if we want add install issues)
- create a folder name `install_issues`
- create `__category__.json`, set `"isTab": true`

``` json
 {
  "label": "install issues",
  "position": 5,
  "isTab": true
}
```
- add `window_install_issues.md` docs, remember to add `{{tab}}` to doc, when render will change to tabs
``` md
---
sidebar_position: 1
title: Window install Issues
---

# Installation Troubleshooting

{{tab}}

```
- add `linux_install_issues.md` docs, remember to add `{{tab}}` to doc, when render will change to tabs

``` md
---
sidebar_position: 0
title: Linux install Issues
---

# Installation Troubleshooting

{{tab}}

### Linux issues

```
