### PR TITLE
fix netlify build error

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
   environment = { NODE_VERSION = "14" }
 
 [context.production]
-  command = "yarn run crowdin:upload && yarn build"
+  command = "yarn build && yarn run crowdin:upload"
 
 [context.deploy-preview]
   command = "yarn build --locale en"


### PR DESCRIPTION
### Purpose
fix netlify build error

### Changes
change the netlify configuration, run `yarn run build` before `yarn run crowdin:upload`
because if the build failed, then should not run crowdin upload
