### PR TITLE
[Feature] Do not throw on docsite builds to by pass historical broken links.

### DIFF
--- a/.github/workflows/doc-sync.yml
+++ b/.github/workflows/doc-sync.yml
@@ -6,6 +6,9 @@ on:
     - cron: '0 */3 * * *'
   workflow_dispatch:
 
+env:
+  DO_NOT_THROW_ON_BROKEN_LINKS: 'true'
+
 jobs:
   sync-docs:
     runs-on: "ubuntu-20.04"

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -50,7 +50,7 @@ module.exports = {
   url: presets[chosenPreset].url,
   baseUrl: presets[chosenPreset].baseUrl,
   // trailingSlash: false,
-  onBrokenLinks: 'throw',
+  onBrokenLinks: process.env.DO_NOT_THROW_ON_BROKEN_LINKS ? 'error' : 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/black_or_white.svg',
   organizationName: 'taichi-dev',


### PR DESCRIPTION
<!-- Welcome to Taichi's documentation site and thank you for your contribution! -->

### Purpose
<!-- Please explain the purpose of this PR OR include links to any ticket that it fixes: -->

- This is to bypass issues reflected in #719 and related PRs.

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

<!-- TO DOCUMENTATION WRITERS: Please always work on `website/docs/develop` only, which is the latest "develop" directory of the documentation. Think twice if you really need to update other older versions of the docs! -->

- Add a flag for stop throwing.
- Configure docusaurus so that it doesn't throw on docsite builds to by pass historical broken links.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
