### PR TITLE
Set max-parallel to 2 to avoid build conflict 

### DIFF
--- a/.github/workflows/doc-sync.yml
+++ b/.github/workflows/doc-sync.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   sync-docs:
+    strategy:
+      max-parallel: 2
     runs-on: "ubuntu-20.04"
     steps:
       - name: Checkout Taichi main repo


### PR DESCRIPTION
According to this page, set `max-parallel=2` to avoid the "another build is running" error